### PR TITLE
[add] 增加阿里巴巴图像检索拍立淘Paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ The main goal is collect classical and solid work of image retrieval in academia
 
 - [Videntifier](http://videntifier.com/) is a visual search engine based on a patented large-scale local feature database, [demo](http://flickrdemo.videntifier.com/), based on SIFT feature and NV-tree.
 - [Web-Scale Responsive Visual Search at Bing](https://arxiv.org/abs/1802.04914)
+- [Visual Search at Alibaba](https://dl.acm.org/citation.cfm?id=3219819.3219820)
 - [Visual Search at Pinterest](https://labs.pinterest.com/user/themes/pinlabs/assets/paper/visual_search_at_pinterest.pdf)
 - [Visual Discovery at Pinterest](https://arxiv.org/abs/1702.04680)
 - [Visual Search at ebay]()


### PR DESCRIPTION
添加18年，阿里发布的拍立淘系统图像检索的Paper-Proceedings of the 24th ACM SIGKDD International Conference on Knowledge Discovery & Data Mining - KDD '18